### PR TITLE
Fetch latest on Windows by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ zip = { version = "0.5", default-features = false, features = ["deflate"] }
 [target.'cfg(not(target_env = "msvc"))'.build-dependencies]
 cc = "1.0"
 
+[target.'cfg(windows)'.build-dependencies]
+ureq = { version = "2.2", optional = false, default-features = false, features = ["tls"] }
+
 [dependencies]
 libc = { version = "0.2" , default-features = false }
 

--- a/build.rs
+++ b/build.rs
@@ -12,7 +12,7 @@ extern crate libflate;
 extern crate minisign_verify;
 extern crate pkg_config;
 extern crate tar;
-#[cfg(feature = "fetch-latest")]
+#[cfg(any(windows, feature = "fetch-latest"))]
 extern crate ureq;
 
 use std::{
@@ -421,7 +421,7 @@ fn retrieve_and_verify_archive(filename: &str, signature_filename: &str) -> Vec<
 
     let mut archive_bin = vec![];
 
-    #[cfg(feature = "fetch-latest")]
+    #[cfg(any(windows, feature = "fetch-latest"))]
     {
         let baseurl = "https://download.libsodium.org/libsodium/releases";
         let response = ureq::get(&format!("{}/{}", baseurl, filename)).call();
@@ -448,7 +448,7 @@ fn retrieve_and_verify_archive(filename: &str, signature_filename: &str) -> Vec<
             .unwrap();
     }
 
-    #[cfg(not(feature = "fetch-latest"))]
+    #[cfg(not(any(windows, feature = "fetch-latest")))]
     {
         File::open(&filename)
             .unwrap()


### PR DESCRIPTION
Hey, sorry for the inconvenience with the previous PR, wasn't aware that you wouldn't be able to push the Windows artefacts to Crates.io.

This PR changes the build configuration for Windows so that it always downloads the latest MSVC/MinGW prebuilt binaries by default, since they can't be shipped as part of the crate.

Thanks!