### PR TITLE
feat(build): add SODIUM_BASE_URL for download

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -407,7 +407,7 @@ fn retrieve_and_verify_archive(filename: &str, signature_filename: &str) -> Vec<
         }
     }
     if download {
-        let baseurl = "http://download.libsodium.org/libsodium/releases";
+        let baseurl = std::env::var("SODIUM_BASE_URL").unwrap_or("http://download.libsodium.org/libsodium/releases".into());
         let agent = ureq::AgentBuilder::new()
             .try_proxy_from_env(true)
             .timeout(std::time::Duration::from_secs(300))


### PR DESCRIPTION
this PR add `SODIUM_BASE_URL` env var for building in some restricted network, which have owned mirror site for speed up and accessibility.

