### PR TITLE
Emphasize on the non-portability of `optimized` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ versions of libsodium instead of point releases.
 ## Cargo Features
 
 - `fetch-latest`: Download the latest stable version of libsodium
-- `optimized`: Build a version optimized for the current platform
+- `optimized`: Optimize for the native CPU - The resulting library will be faster but not portable
 - `minimal`: Do not build deprecated APIs
 - `use-pkg-config`: Force the use of pkg-config to find libsodium
 - `wasi-component`: Build as a WASI component exposing libsodium functions


### PR DESCRIPTION
My team just got bite by the `optimize` feature that we enabled by mistake.

Currently the documentation for this feature is `Build a version optimized for the current platform`, it is a bit vague about what the tradeoff is (I guess we read it a bit fast, overlook the "platform" and assume it was a "optimized vs debug" build flag... and so we enabled it :sweat_smile: )

I find the wording of the libsodium's `--enable-opt` (i.e. the option that `optimize` feature activates) documentation much clearer, so I suggest to also use here.

PS: This PR is totally trivial, so feel free to do the correction without merging it ;-)